### PR TITLE
fix: use explicit await before casting response.json()

### DIFF
--- a/src/api/useBudgetPlan.ts
+++ b/src/api/useBudgetPlan.ts
@@ -52,7 +52,8 @@ const useBudgetPlan: HookType = (planId?: number) => {
                 throw new Error("Failed to create budget plan");
             }
 
-            return response.json() as unknown as BudgetPlan;
+            const data = await response.json();
+            return data as BudgetPlan;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ["budgetPlans"]});
@@ -77,7 +78,8 @@ const useBudgetPlan: HookType = (planId?: number) => {
                 throw new Error("Failed to update budget plan");
             }
 
-            return response.json() as unknown as BudgetPlan;
+            const data = await response.json();
+            return data as BudgetPlan;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ["budgetPlans"]});

--- a/src/api/useBudgetPlanItem.ts
+++ b/src/api/useBudgetPlanItem.ts
@@ -24,7 +24,8 @@ const useBudgetPlanItem: HookType = () => {
                 throw new Error("Failed to create budget plan item");
             }
 
-            return response.json() as unknown as BudgetPlanItem;
+            const data = await response.json();
+            return data as BudgetPlanItem;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ["budgetPlanDetails"]});
@@ -45,7 +46,8 @@ const useBudgetPlanItem: HookType = () => {
                 throw new Error("Failed to update budget plan item");
             }
 
-            return response.json() as unknown as BudgetPlanItem;
+            const data = await response.json();
+            return data as BudgetPlanItem;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ["budgetPlanDetails"]});

--- a/src/api/useClickUp.ts
+++ b/src/api/useClickUp.ts
@@ -153,7 +153,8 @@ const useClickUp: HookType = (budgetPlanId?: number) => {
             if (!response.ok) {
                 throw new Error("ClickUp integration authentication failed");
             }
-            return (response.json()) as unknown as ClickUpAuthRedirect;
+            const data = await response.json();
+            return data as ClickUpAuthRedirect;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ["currentProfile"]});

--- a/src/api/useGoogle.ts
+++ b/src/api/useGoogle.ts
@@ -36,7 +36,8 @@ const useGoogle: HookType = () => {
             if (!response.ok) {
                 throw new Error("Google integration authentication failed");
             }
-            return (response.json()) as unknown as GoogleAuthRedirect;
+            const data = await response.json();
+            return data as GoogleAuthRedirect;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ["currentProfile"]});

--- a/src/api/useWeeklyPlan.ts
+++ b/src/api/useWeeklyPlan.ts
@@ -45,7 +45,8 @@ const useWeeklyPlan: HookType = (inWeekDate: Date) => {
                 throw new Error("Failed to reset weekly plan");
             }
 
-            return response.json() as unknown as WeeklyPlan;
+            const data = await response.json();
+            return data as WeeklyPlan;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["weeklyPlan"] });
@@ -66,7 +67,8 @@ const useWeeklyPlan: HookType = (inWeekDate: Date) => {
                 throw new Error("Failed to update weekly plan item");
             }
 
-            return response.json() as unknown as WeeklyPlanItem;
+            const data = await response.json();
+            return data as WeeklyPlanItem;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["weeklyPlan"] });
@@ -87,7 +89,8 @@ const useWeeklyPlan: HookType = (inWeekDate: Date) => {
                 throw new Error("Failed to reset weekly plan item");
             }
 
-            return response.json() as unknown as WeeklyPlanItem;
+            const data = await response.json();
+            return data as WeeklyPlanItem;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["weeklyPlan"] });
@@ -106,7 +109,8 @@ const useWeeklyPlan: HookType = (inWeekDate: Date) => {
             if (!response.ok) {
                 throw new Error("Failed to set off week");
             }
-            return response.json() as unknown as WeeklyPlan;
+            const data = await response.json();
+            return data as WeeklyPlan;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["weeklyPlan"] });


### PR DESCRIPTION
`response.json()` returns `Promise<any>`. Casting it directly to a typed object (e.g. `as BudgetPlan`) breaks `tsc -b` because `Promise<any>` and the target type have no structural overlap.

Replace all 10 occurrences in 5 API files with:
```ts
const data = await response.json();
return data as T;
```