### PR TITLE
fix: default `eventCalendarType` to "klokku" and remove empty string …

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -90,7 +90,7 @@ export interface CurrentEventPlanItem {
 export interface ProfileSettings {
     timezone: string;
     weekStartDay: "monday" | "sunday";
-    eventCalendarType: "google" | "klokku" | "";
+    eventCalendarType: "google" | "klokku";
     googleCalendar?: {
         calendarId: string;
     };

--- a/src/pages/profile/CreateProfilePage.tsx
+++ b/src/pages/profile/CreateProfilePage.tsx
@@ -59,7 +59,7 @@ export function CreateProfilePage() {
             settings: {
                 timezone: formData.timezone,
                 weekStartDay: formData.weekStartDay,
-                eventCalendarType: "",
+                eventCalendarType: "klokku",
                 ignoreShortEvents: false,
             }
         });

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -33,10 +33,9 @@ export function ProfileForm({profile, onSave}: Props) {
             displayName: formData.displayName,
             photoUrl: formData.photoUrl || "",
             settings: {
+                ...profile.settings,
                 timezone: formData.timezone,
                 weekStartDay: formData.weekStartDay,
-                eventCalendarType: "",
-                ignoreShortEvents: profile?.settings.ignoreShortEvents ?? false,
             }
         });
     }


### PR DESCRIPTION
## Problem

Some users' `event_calendar_type` was being silently reset to an empty string in
the database. This wiped their calendar selection (e.g. `google` → empty),
breaking calendar integration.

## Root cause

The profile edit form rebuilt the entire `settings` object from scratch and
hardcoded `eventCalendarType: ""`, then `PUT /api/user/current` sent the whole
profile. The backend's `UpdateUser` performs a full-column overwrite with no
default, so the empty string was written straight into the DB.

This only affected the **update** path. The **create** path never hit the bug
because `UserRepoImpl.CreateUser` already defaults an empty value to `klokku`
before inserting — a guard that `UpdateUser` was missing. So the symptom only
appeared after a user edited their profile (display name, username, timezone, or
week start day) once a calendar type had been set.

## Changes

### UI (the actual bug)
- **`ProfileForm.tsx`**: spread `...profile.settings` on save instead of
  rebuilding it, preserving `eventCalendarType`, `googleCalendar`, and
  `ignoreShortEvents`.
- **`types.ts`**: tightened `eventCalendarType` to `"google" | "klokku"`
  (removed `| ""`) so the compiler catches any future attempt to blank it.
- **`CreateProfilePage.tsx`**: set the default to `"klokku"` instead of `""`.

### Backend (defense in depth)
- **Default**: `UpdateUser`/`CreateUser` now fall back to `KlokkuCalendar` when
  the field is empty, so no client can blank it via the overwrite UPDATE.
- **Validation**: added `EventCalendarType.IsValid()`; invalid values are now
  rejected (`ErrUserDataInvalid`) instead of silently stored.
- **DB backstop** (`migrations/0005_user_event_calendar_type_default.up.sql`):
  backfills existing blank rows to `'klokku'`, sets column `DEFAULT 'klokku'`,
  and adds `CHECK (event_calendar_type IN ('klokku','google'))`.

## Migration notes
- The migration backfills existing blanked rows **before** adding the `CHECK`
  constraint, so it applies cleanly to affected databases.