### PR TITLE
feat: show weekly plan notes and duration override badge on current plan page

### DIFF
--- a/src/pages/history/WeeklyHistory.tsx
+++ b/src/pages/history/WeeklyHistory.tsx
@@ -1,11 +1,13 @@
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from "@/components/ui/table.tsx";
 import {differenceInSeconds} from "date-fns";
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@/components/ui/tooltip.tsx";
-import {ReplaceIcon, TimerIcon, TriangleAlertIcon} from "lucide-react";
+import {TextAlignStartIcon, TimerIcon, TriangleAlertIcon} from "lucide-react";
 import {formatSecondsToDuration} from "@/lib/dateUtils.ts";
 import {CurrentEvent, StatsSummary} from "@/api/types.ts";
 import {Spinner} from "@/components/ui/spinner.tsx";
 import {ProgressCell} from "@/pages/history/ProgressCell.tsx";
+import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover.tsx";
+import {Badge} from "@/components/ui/badge.tsx";
 
 interface WeeklyStatisticsProps {
     weekData?: StatsSummary
@@ -46,7 +48,10 @@ export function WeeklyHistory({weekData, currentEvent}: WeeklyStatisticsProps) {
                     </TableRow>
                 </TableHeader>
                 <TableBody>
-                    {weekData!.perPlanItem.map((stat) => (
+                    {weekData!.perPlanItem.map((stat) => {
+                        const diff = stat.planItem.weeklyItemDuration - stat.planItem.budgetItemDuration;
+                        const isModified = stat.planItem.weeklyItemDuration !== stat.planItem.budgetItemDuration;
+                        return (
                         <TableRow className="h-full p-0" key={stat.planItem.budgetItemId}>
                             <TableCell className="font-medium bg-gray-50 flex items-center space-x-2">
                                 <span>{stat.planItem.name}</span>
@@ -64,21 +69,33 @@ export function WeeklyHistory({weekData, currentEvent}: WeeklyStatisticsProps) {
                                 )}
                             </TableCell>
                             <TableCell>
-                                <div className="flex items-center space-x-2">
-                                    <div>
-                                        {formatSecondsToDuration(stat.planItem.weeklyItemDuration)}
-                                    </div>
-                                    {stat.planItem.weeklyItemDuration !== stat.planItem.budgetItemDuration && (
-                                        <TooltipProvider>
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <ReplaceIcon className="size-4"/>
-                                                </TooltipTrigger>
-                                                <TooltipContent>
-                                                    Original time: {formatSecondsToDuration(stat.planItem.budgetItemDuration)}
-                                                </TooltipContent>
-                                            </Tooltip>
-                                        </TooltipProvider>
+                                <div className="flex items-center gap-1.5">
+                                    {/* Duration value */}
+                                    {!isModified && (
+                                        <span>{formatSecondsToDuration(stat.planItem.weeklyItemDuration)}</span>
+                                    )}
+                                    {isModified && (
+                                        <span className="font-medium">{formatSecondsToDuration(stat.planItem.weeklyItemDuration)}</span>
+                                    )}
+                                    {isModified && !stat.planItem.notes && (
+                                        <Badge variant="secondary" className="text-xs font-normal">
+                                            {diff > 0 ? '+' : '-'}{formatSecondsToDuration(diff, true)}
+                                        </Badge>
+                                    )}
+                                    {stat.planItem.notes && (
+                                        <Popover>
+                                            <PopoverTrigger asChild>
+                                                <Badge variant="secondary" className="text-xs font-normal cursor-pointer">
+                                                    {isModified && (
+                                                        <span>{diff > 0 ? '+' : '-'}{formatSecondsToDuration(diff, true)}</span>
+                                                    )}
+                                                    <TextAlignStartIcon className="size-3.5 text-gray-400 ml-1"/>
+                                                </Badge>
+                                            </PopoverTrigger>
+                                            <PopoverContent className="max-w-xs">
+                                                <p className="text-sm whitespace-pre-wrap">{stat.planItem.notes}</p>
+                                            </PopoverContent>
+                                        </Popover>
                                     )}
                                 </div>
                             </TableCell>
@@ -88,7 +105,8 @@ export function WeeklyHistory({weekData, currentEvent}: WeeklyStatisticsProps) {
                             </TableCell>
                             <TableCell>{formatSecondsToDuration(stat.remaining)}</TableCell>
                         </TableRow>
-                    ))}
+                        );
+                    })}
                     <TableRow className="h-full p-0 bg-gray-100">
                         <TableCell className="font-bold">SUM</TableCell>
                         <TableCell className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary

Shows weekly-plan notes and the duration override diff on the Weekly tab of `/history/current-plan`, mirroring how they appear on the weekly planning page (`planning/weekly`). Both are read-only and tap-friendly on mobile.

## Changes

- Replaced the `ReplaceIcon` + tooltip on the Weekly history view with an always-visible badge showing the duration diff vs. the original budget (e.g. `+3h 30m`), so it works on mobile where hover tooltips don\'t.
- Renders a note icon inside the same badge when the weekly plan item has notes. Clicking the badge opens a popover with the full note text, identical to the weekly planning page affordance.
- No backend changes - the stats API (`StatsSummary`/`PlanItem`) already returns `notes` and `budgetItemDuration`.

## Behavior

- Not modified, no note → duration text only.
- Modified, no note → duration + plain badge with `+/-<diff>`.
- Note present (modified or not) → duration + badge with diff (if modified) + note icon; whole badge is the popover trigger.

## Scope

- Weekly tab only. Daily tab unchanged.
- Current-event `TimerIcon` tooltip kept as-is (out of scope).

## Verification

- `npm run lint` - no new issues.
- `tsc -b` - no errors.