### PR TITLE
Add budget plan duplication UI

### DIFF
--- a/src/api/useBudgetPlan.ts
+++ b/src/api/useBudgetPlan.ts
@@ -8,6 +8,7 @@ type HookType = (planId?: number) => {
     budgetPlanDetails?: BudgetPlan
     isLoadingBudgetPlanDetails: boolean
     createBudgetPlan: (createPlanData: { name: string }) => Promise<BudgetPlan>;
+    duplicateBudgetPlan: (planId: number, newName: string) => Promise<BudgetPlan>;
     updateBudgetPlan: (planId: number, updatePlanData: { name: string, isCurrent: boolean }) => Promise<BudgetPlan>;
     deleteBudgetPlan: (planId: number) => Promise<void>;
 };
@@ -89,6 +90,28 @@ const useBudgetPlan: HookType = (planId?: number) => {
         },
     });
 
+    const duplicate = useMutation({
+        mutationFn: async (duplicateData: { planId: number, newName: string }) => {
+            const response = await fetchWithAuth(`/api/budgetplan/${duplicateData.planId}/duplicate`, {
+                method: "POST",
+                body: JSON.stringify({name: duplicateData.newName}),
+            });
+
+            if (!response.ok) {
+                throw new Error("Failed to duplicate budget plan");
+            }
+
+            const data = await response.json();
+            return data as BudgetPlan;
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ["budgetPlans"]});
+        },
+        onError: (error) => {
+            console.log(">>>error", error);
+        },
+    });
+
     const deleteMutation = useMutation({
         mutationFn: async (planId: number) => {
             const response = await fetchWithAuth(`/api/budgetplan/${planId}`, {
@@ -111,6 +134,10 @@ const useBudgetPlan: HookType = (planId?: number) => {
         return create.mutateAsync(createPlanData);
     };
 
+    const duplicateBudgetPlan = async (planId: number, newName: string) => {
+        return duplicate.mutateAsync({planId, newName});
+    };
+
     const updateBudgetPlan = async (planId: number, updatePlanData: {name: string, isCurrent: boolean}) => {
         return update.mutateAsync({planId: planId, name: updatePlanData.name, isCurrent: updatePlanData.isCurrent});
     };
@@ -125,6 +152,7 @@ const useBudgetPlan: HookType = (planId?: number) => {
         budgetPlanDetails,
         isLoadingBudgetPlanDetails,
         createBudgetPlan,
+        duplicateBudgetPlan,
         updateBudgetPlan,
         deleteBudgetPlan,
     };

--- a/src/components/budgetPlan/BudgetPlanEdit.tsx
+++ b/src/components/budgetPlan/BudgetPlanEdit.tsx
@@ -5,7 +5,7 @@ import {Button} from "@/components/ui/button.tsx";
 import {useState} from "react";
 
 interface Props {
-    action: "rename" | "create";
+    action: "rename" | "create" | "duplicate";
     planName?: string;
     open: boolean;
     onOpenChange: (open: boolean) => void;
@@ -14,7 +14,11 @@ interface Props {
 
 export function BudgetPlanEdit({action, planName, open, onOpenChange, onSave}: Props) {
 
-    const [planNameState, setPlanName] = useState(action === "rename" ? planName || "" : "");
+    const [planNameState, setPlanName] = useState(
+        action === "rename" ? planName || "" :
+        action === "duplicate" ? `${planName || ""} (copy)` :
+        ""
+    );
 
     const save = () => {
         onSave(planNameState);
@@ -24,11 +28,19 @@ export function BudgetPlanEdit({action, planName, open, onOpenChange, onSave}: P
         onOpenChange(false);
     }
 
+    const title = action === "create" ? "Create New Budget Plan" :
+                  action === "duplicate" ? "Duplicate Plan" :
+                  "Rename Budget Plan";
+
+    const buttonLabel = action === "create" ? "Create Plan" :
+                        action === "duplicate" ? "Duplicate Plan" :
+                        "Save changes";
+
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="sm:max-w-[425px]">
                 <DialogHeader>
-                    <DialogTitle>{action === "create" ? "Create New Budget Plan" : "Rename Budget Plan"}</DialogTitle>
+                    <DialogTitle>{title}</DialogTitle>
                 </DialogHeader>
                 <div className="grid gap-4 py-4">
                     <div className="grid grid-cols-4 items-center gap-4">
@@ -45,7 +57,7 @@ export function BudgetPlanEdit({action, planName, open, onOpenChange, onSave}: P
                 <DialogFooter>
                     <Button variant="outline" onClick={cancel}>Cancel</Button>
                     <Button onClick={save}>
-                        {action === "create" ? "Create Plan" : "Save changes"}
+                        {buttonLabel}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/src/pages/budgetPlan/BudgetPlanChooser.tsx
+++ b/src/pages/budgetPlan/BudgetPlanChooser.tsx
@@ -1,6 +1,6 @@
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger} from "@/components/ui/dropdown-menu.tsx";
 import {Button} from "@/components/ui/button.tsx";
-import {CheckIcon, PencilIcon, PlusIcon, Settings2Icon, Trash2Icon} from "lucide-react";
+import {CheckIcon, CopyIcon, PencilIcon, PlusIcon, Settings2Icon, Trash2Icon} from "lucide-react";
 import {BudgetPlan} from "@/api/types.ts";
 import {useState} from "react";
 import useBudgetPlan from "@/api/useBudgetPlan.ts";
@@ -25,12 +25,12 @@ interface BudgetPlanChooserProps {
 
 export function BudgetPlanChooser({budgetPlans, selectedPlanId, setSelectedPlanId}: BudgetPlanChooserProps) {
 
-    const {updateBudgetPlan, createBudgetPlan, deleteBudgetPlan} = useBudgetPlan();
+    const {updateBudgetPlan, createBudgetPlan, deleteBudgetPlan, duplicateBudgetPlan} = useBudgetPlan();
 
     const currentPlanId = budgetPlans.find(p => p.isCurrent)?.id;
     const selectedPlan = budgetPlans.find(p => p.id === selectedPlanId);
 
-    const [planAction, setPlanAction] = useState<"rename" | "create" | undefined>(undefined);
+    const [planAction, setPlanAction] = useState<"rename" | "create" | "duplicate" | undefined>(undefined);
     const [isDeleting, setIsDeleting] = useState(false);
 
     const handleRename = async (newName: string) => {
@@ -50,6 +50,13 @@ export function BudgetPlanChooser({budgetPlans, selectedPlanId, setSelectedPlanI
     const handleCreate = async (planName: string) => {
         if (planName.trim()) {
             const newPlan = await createBudgetPlan({name: planName});
+            setSelectedPlanId(newPlan.id);
+        }
+    };
+
+    const handleDuplicate = async (newName: string) => {
+        if (selectedPlanId && newName.trim()) {
+            const newPlan = await duplicateBudgetPlan(selectedPlanId, newName);
             setSelectedPlanId(newPlan.id);
         }
     };
@@ -82,6 +89,14 @@ export function BudgetPlanChooser({budgetPlans, selectedPlanId, setSelectedPlanI
                                 </DropdownMenuItem>
                             )}
                             <DropdownMenuSeparator/>
+                            {selectedPlanId && (
+                                <DropdownMenuItem onClick={() => {
+                                    setPlanAction("duplicate");
+                                }}>
+                                    <CopyIcon className="mr-2 size-4"/>
+                                    Duplicate Plan
+                                </DropdownMenuItem>
+                            )}
                             <DropdownMenuItem onClick={() => {
                                 setPlanAction("create");
                             }}>
@@ -113,6 +128,8 @@ export function BudgetPlanChooser({budgetPlans, selectedPlanId, setSelectedPlanI
                     onSave={async (name) => {
                         if (planAction === "create") {
                             await handleCreate(name);
+                        } else if (planAction === "duplicate") {
+                            await handleDuplicate(name);
                         } else if (planAction === "rename") {
                             await handleRename(name);
                         }


### PR DESCRIPTION
## What
Add a 'Duplicate Plan' menu item to the BudgetPlanChooser dropdown so users can clone an existing budget plan instead of creating one from scratch.

## UI changes
- **BudgetPlanChooser**: new 'Duplicate Plan' `DropdownMenuItem` with `CopyIcon`, rendered only when a plan is selected. On confirm, calls the backend `POST /api/budgetplan/{planId}/duplicate` and switches to the new plan.
- **BudgetPlanEdit**: extended `action` prop to accept `"duplicate"`. Pre-fills the name field with `"<original>" + " (copy)"`, shows 'Duplicate Plan' title and button label.
- **useBudgetPlan**: new `duplicateBudgetPlan(planId, newName)` mutation that POSTs to the new endpoint and invalidates `["budgetPlans"]`.

## Depends on
Backend PR: https://github.com/klokku/klokku/pull/33